### PR TITLE
Modified  CLOptionText and CLOptionPresent to accept the command line…

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -514,7 +514,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.4.2;
+				MARKETING_VERSION = 0.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -541,7 +541,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.4.2;
+				MARKETING_VERSION = 0.4.3;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>574</string>
+	<string>614</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/UI/ContentView.swift
+++ b/dialog/UI/ContentView.swift
@@ -78,12 +78,12 @@ struct HostingWindowFinder: NSViewRepresentable {
         let view = NSView()
         
         // process command line options that just display info and exit before we show the main window
-        if CLOptionPresent(OptionName: CLOptions.getVersion) {
-            printVersionString()
-            exit(0)
-        }
         if (CLOptionPresent(OptionName: CLOptions.helpOption) || CommandLine.arguments.count == 1) {
             print(helpText)
+            exit(0)
+        }
+        if CLOptionPresent(OptionName: CLOptions.getVersion) {
+            printVersionString()
             exit(0)
         }
         if CLOptionPresent(OptionName: CLOptions.showLicense) {

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -16,80 +16,99 @@ var appvars = AppVariables()
 
 var helpText = """
     Dialog version \(getVersionString()) ©2021 Bart Reardon
-    --title             Set the Dialog title
-                        Text over 40 characters gets truncated
-                        Default Title is "\(appvars.titleDefault)"
-    
-    --message           Set the dialog message
-                        Message length is up to approximately 80 words
-    
-    --icon              Set the icon to display
-                        Acceptable Values:
-                        file path to png or jpg           -  "/file/path/image.[png|jpg]"
-                        file path to Application          -  "/Applications/Chess.app"
-                        URL of file resource              -  "https://someurl/file.[png|jpg]"
-                        builtin                           -  info | caution | warning
 
-                        if not specified, default icon will be used
-                        Images from either file or URL are displayed as roundrect if no transparancy
+    OPTIONS:
+        -\(CLOptions.titleOption.short), --\(CLOptions.titleOption.long) <text>
+                    Set the Dialog title
+                    Text over 40 characters gets truncated
+                    Default Title is "\(appvars.titleDefault)"
+        
+        -\(CLOptions.messageOption.short), --\(CLOptions.messageOption.long) <text>
+                    Set the dialog message
+                    Message length is up to approximately 80 words
+        
+        -\(CLOptions.iconOption.short), --\(CLOptions.iconOption.long) <file> | <url>
+                    Set the icon to display
+                    Acceptable Values:
+                    file path to png or jpg           -  "/file/path/image.[png|jpg]"
+                    file path to Application          -  "/Applications/Chess.app"
+                    URL of file resource              -  "https://someurl/file.[png|jpg]"
+                    builtin                           -  info | caution | warning
 
-    --overlayicon       Set an image to display as an overlay to --icon
-                        image is displayed at 1/2 resolution to the main image and positioned to the bottom right
-                        Acceptable Values:
-                        file path to png or jpg           -  "/file/path/image.[png|jpg]"
-                        file path to Application          -  "/Applications/Chess.app"
-                        URL of file resource              -  "https://someurl/file.[png|jpg]"
-                        builtin                           -  info | caution | warning
+                    if not specified, default icon will be used
+                    Images from either file or URL are displayed as roundrect if no transparancy
 
-    --infoicon          (Deprecated - use "--icon info" instead) Built in. Displays person with questionmark as the icon
+        -\(CLOptions.overlayIconOption.short), --\(CLOptions.overlayIconOption.long) <file> | <url>
+                    Set an image to display as an overlay to --icon
+                    image is displayed at 1/2 resolution to the main image and positioned to the bottom right
+                    Acceptable Values:
+                    file path to png or jpg           -  "/file/path/image.[png|jpg]"
+                    file path to Application          -  "/Applications/Chess.app"
+                    URL of file resource              -  "https://someurl/file.[png|jpg]"
+                    builtin                           -  info | caution | warning
+        
+        -\(CLOptions.hideIcon.short), --\(CLOptions.hideIcon.long)
+                    Hides the icon from view
+                    Doing so increases the space available for message text to approximately 100 words
 
-    --cautionicon       (Deprecated - use "--icon caution" instead) Built in. Displays yellow triangle with exclamation point
+        --\(CLOptions.button1TextOption.long) <text>
+                    Set the label for Button1
+                    Default label is "\(appvars.button1Default)"
+                    Bound to <Enter> key
 
-    --warningicon       (Deprecated - use "--icon warning" instead) Built in. Displays red octagon with exclamation point
-    
-    --hideicon          hides the icon from view
-                        Doing so increases the space available for message text to approximately 100 words
+        --\(CLOptions.button1ActionOption.long) <url>
+                    Set the action to take.
+                    Accepts URL
+                    Default action if not specified is no action
+                    Return code when actioned is 0
 
-    --button1text       Set the label for Button1
-                        Default label is "\(appvars.button1Default)"
-                        Bound to <Enter> key
+        -\(CLOptions.button2Option.short), --\(CLOptions.button2Option.long)
+                    Displays button2 with default label of "\(appvars.button2Default)"
+            OR
 
-    --button1action     Set the action to take.
-                        Accepts URL
-                        Default action if not specified is no action
-                        Return code when actioned is 0
+        --\(CLOptions.button2TextOption.long) <text>
+                    Set the label for Button1
+                    Bound to <ESC> key
 
-    --button2           Displays button2 with default label of "\(appvars.button2Default)"
-        OR
-    --button2text       Set the label for Button1
-                        Bound to <ESC> key
+        --\(CLOptions.button2ActionOption.long) <url>
+                    Return code when actioned is 2
+                    -- Setting Custon Actions For Button 2 Is Not Implemented at this time --
 
-    --button2action     Return code when actioned is 2
-                        -- Setting Custon Actions For Button 2 Is Not Implemented at this time --
+        -\(CLOptions.infoButtonOption.short), --\(CLOptions.infoButtonOption.long)
+                    Displays info button with default label of "\(appvars.buttonInfoDefault)"
+            
+            OR
 
-    --infobutton        Displays button2 with default label of "\(appvars.buttonInfoDefault)"
-        OR
-    --infobuttontext    Set the label for Information Button
-                        If not specified, Info button will not be displayed
-                        Return code when actioned is 3
+        --\(CLOptions.buttonInfoTextOption.long) <text>
+                    Set the label for Information Button
+                    If not specified, Info button will not be displayed
+                    Return code when actioned is 3
 
-    --infobuttonaction  Set the action to take.
-                        Accepts URL
-                        Default action if not specified is no action
+        --\(CLOptions.buttonInfoActionOption.long)  <url>
+                    Set the action to take.
+                    Accepts URL
+                    Default action if not specified is no action
 
-    --moveable          Let window me moved around the screen. Default is not moveable
+        -\(CLOptions.lockWindow.short), --\(CLOptions.lockWindow.long)
+                    Let window me moved around the screen. Default is not moveable
 
-    --ontop             Make the window appear above all other windows even when not active
+        -\(CLOptions.forceOnTop.short), --\(CLOptions.forceOnTop.long)
+                    Make the window appear above all other windows even when not active
 
-    --big               Makes the dialog 25% bigger than normal. More room for message text
+        -\(CLOptions.bigWindow.short), --\(CLOptions.bigWindow.long)
+                    Makes the dialog 25% bigger than normal. More room for message text
 
-    --small             Makes the dialog 25% smaller. Less room for message text.
+        -\(CLOptions.smallWindow.short), --\(CLOptions.smallWindow.long)
+                    Makes the dialog 25% smaller. Less room for message text.
 
-    --version           Prints the app version
+        -\(CLOptions.getVersion.short), --\(CLOptions.getVersion.long)
+                    Prints the app version
 
-    --showlicense       Display the Software License Agreement for Dialog
+        -\(CLOptions.showLicense.short), --\(CLOptions.showLicense.long)
+                    Display the Software License Agreement for Dialog
 
-    --help              Prints this text
+        --\(CLOptions.helpOption.long)
+                    Prints this text
     """
 
 struct AppVariables {
@@ -140,33 +159,35 @@ struct AppVariables {
 
 
 struct CLOptions {
-    static let titleOption              = String("--title")
-    static let messageOption            = String("--message")
-    static let iconOption               = String("--icon")
-    static let overlayIconOption        = String("--overlayicon")
-    static let button1TextOption        = String("--button1text")
-    static let button1ActionOption      = String("--button1action")
-    static let button2TextOption        = String("--button2text")
-    static let button2ActionOption      = String("--button2action")
-    static let buttonInfoTextOption     = String("--infobuttontext")
-    static let buttonInfoActionOption   = String("--infobuttonaction")
+    // command line options that take string parameters
+    static let titleOption              = (long: String("title"),             short: String("t"))  // -t
+    static let messageOption            = (long: String("message"),           short: String("m"))  // -m
+    static let iconOption               = (long: String("icon"),              short: String("i"))  // -i
+    static let overlayIconOption        = (long: String("overlayicon"),       short: String("y"))
+    static let button1TextOption        = (long: String("button1text"),       short: String(""))
+    static let button1ActionOption      = (long: String("button1action"),     short: String(""))
+    static let button2TextOption        = (long: String("button2text"),       short: String(""))
+    static let button2ActionOption      = (long: String("button2action"),     short: String(""))
+    static let buttonInfoTextOption     = (long: String("infobuttontext"),    short: String(""))
+    static let buttonInfoActionOption   = (long: String("infobuttonaction"),  short: String(""))
    
     // command line options that take no additional parameters
-    static let button2Option            = String("--button2")
-    static let infoButtonOption         = String("--infobutton")
-    static let getVersion               = String("--version")
-    static let hideIcon                 = String("--hideicon")
-    static let helpOption               = String("--help")
-    static let demoOption               = String("--demo")
-    static let buyCoffee                = String("--coffee")
-    static let showLicense              = String("--showlicense")
-    static let warningIcon              = String("--warningicon")
-    static let infoIcon                 = String("--infoicon")
-    static let cautionIcon              = String("--cautionicon")
+    static let button2Option            = (long: String("button2"),           short: String("2")) // -2
+    static let infoButtonOption         = (long: String("infobutton"),        short: String("3")) // -3
+    static let getVersion               = (long: String("version"),           short: String("v")) // -v
+    static let hideIcon                 = (long: String("hideicon"),          short: String("h")) // -h
+    static let helpOption               = (long: String("help"),              short: String(""))
+    static let demoOption               = (long: String("demo"),              short: String(""))
+    static let buyCoffee                = (long: String("coffee"),            short: String("☕️"))
+    static let showLicense              = (long: String("showlicense"),       short: String("l"))
+    static let warningIcon              = (long: String("warningicon"),       short: String("")) // Deprecated
+    static let infoIcon                 = (long: String("infoicon"),          short: String("")) // Deprecated
+    static let cautionIcon              = (long: String("cautionicon"),       short: String("")) // Deprecated
     
-    static let lockWindow               = String("--moveable")
-    static let forceOnTop               = String("--ontop")
-    static let smallWindow              = String("--small")
-    static let bigWindow                = String("--big")
+    static let lockWindow               = (long: String("moveable"),          short: String("o")) // -m
+    static let forceOnTop               = (long: String("ontop"),             short: String("p")) // -p
+    static let smallWindow              = (long: String("small"),             short: String("s")) // -s
+    static let bigWindow                = (long: String("big"),               short: String("b")) // -b
 
+    // civhmtsb
 }

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -24,7 +24,7 @@ struct dialogApp: App {
             // scale everything down a notch
             
             appvars.smallWindow = true
-            
+
             appvars.scaleFactor = 0.75
             appvars.dialogContentScale = 0.80
             

--- a/dialog/extras/Options.swift
+++ b/dialog/extras/Options.swift
@@ -10,24 +10,20 @@ import Foundation
 
 // Returns the option text for a given command line option
 
-func CLOptionText(OptionName: String, DefaultValue: String) -> String {
+func CLOptionText(OptionName: (long: String, short: String), DefaultValue: String) -> String {
     // Determine if argument is present.
     var CLOptionTextValue = ""
-    if let commandIndex = CommandLine.arguments.firstIndex(of: OptionName) {
+        
+    if let commandIndex = [CommandLine.arguments.firstIndex(of: "--\(OptionName.long)"), CommandLine.arguments.firstIndex(of: "-\(OptionName.short)")].compactMap({$0}).first {
         // Get next index and ensure it's not out of bounds.
         let valueIndex = CommandLine.arguments.index(after: commandIndex)
         if valueIndex >= CommandLine.arguments.startIndex
             && valueIndex < CommandLine.arguments.endIndex
         {
-            //print("OptionName = \(OptionName)")
-            //print("Option Name Index = \(commandIndex)")
-            //print("valueIndex = \(valueIndex)")
-            //print("CommandLine.arguments.startIndex = \(CommandLine.arguments.startIndex)")
-            //print("CommandLine.arguments.endIndex = \(CommandLine.arguments.endIndex)")
-            //print("---")
+
             CLOptionTextValue = CommandLine.arguments[valueIndex]
-            if (CLOptionTextValue.starts(with: "--")) {
-                print("\(OptionName) has no associated value")
+            if (CLOptionTextValue.starts(with: "-")) {
+                print("Argument \(CommandLine.arguments[commandIndex]) was not passed a value.")
                 CLOptionTextValue = DefaultValue
             } else {
                 CLOptionTextValue = CLOptionTextValue.replacingOccurrences(of:"\\n", with:"\n")
@@ -42,14 +38,19 @@ func CLOptionText(OptionName: String, DefaultValue: String) -> String {
 
 // returns true if the specified oprion is present.
 
-func CLOptionPresent(OptionName: String) -> Bool {
+func CLOptionPresent(OptionName: (long: String, short: String)) -> Bool {
     // Determine if option is present.
     var optionPresent = false
-    if let commandIndex = CommandLine.arguments.firstIndex(of: OptionName) {
+    if let commandIndex = [CommandLine.arguments.firstIndex(of: "--\(OptionName.long)"), CommandLine.arguments.firstIndex(of: "-\(OptionName.short)")].compactMap({$0}).first {
         if commandIndex > 0 {
             optionPresent = true
         }
     }
     return optionPresent
+}
+
+private func returnTextFoCLOption(index: Int) -> String {
+
+    return ""
 }
 


### PR DESCRIPTION
… arguments as a tuple and process accordingly. This allows for multiple arguments to represent the same command

Modified the help text output. Now reads the values stored in CLOptions so if we need to change the long or short command, the help text will reflect the change
Also changed the help text format to be more readable and represent the possible values

moved the detection of the --help command line option to occur first. This ensures you can call help halfway through typing a command to see the help text