### PR TITLE
Added:

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -522,7 +522,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -549,7 +549,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1193</string>
+	<string>1209</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/UI/ButtonView.swift
+++ b/dialog/UI/ButtonView.swift
@@ -10,14 +10,16 @@ import SwiftUI
 
 struct ButtonView: View {
 
-    private func button1Action() {
-        let action: String = CLOptionText(OptionName: CLOptions.button1ActionOption, DefaultValue: "")
-        
-        if (action != "") {
-            openSpecifiedURL(urlToOpen: action)
+    var button1action: String = ""
+    var buttonShellAction: Bool = false
+    
+    init() {
+        if CLOptionPresent(OptionName: CLOptions.button1ShellActionOption) {
+            button1action = CLOptionText(OptionName: CLOptions.button1ShellActionOption , DefaultValue: "")
+            buttonShellAction = true
+        } else if CLOptionPresent(OptionName: CLOptions.button1ActionOption) {
+            button1action = CLOptionText(OptionName: CLOptions.button1ActionOption, DefaultValue: "")
         }
-        quitDialog(exitCode: 0)
-        //exit(0)
     }
     
     var body: some View {
@@ -41,7 +43,7 @@ struct ButtonView: View {
         // default button aka button 1
         let button1Text: String = CLOptionText(OptionName: CLOptions.button1TextOption, DefaultValue: appvars.button1Default)
         HStack {
-            Button(action: {self.button1Action()}, label: {
+            Button(action: {buttonAction(action: self.button1action, exitCode: 0, executeShell: self.buttonShellAction)}, label: {
                 Text(button1Text)
                 }
             ).frame(minWidth: 36, alignment: .center)
@@ -53,17 +55,19 @@ struct ButtonView: View {
 struct MoreInfoButton: View {
     let buttonInfoAction: String = CLOptionText(OptionName: CLOptions.buttonInfoActionOption, DefaultValue: appvars.buttonInfoActionDefault)
     
+    
+    
     var body: some View {
         HStack() {
             
             if CLOptionPresent(OptionName: CLOptions.infoButtonOption) {
-                Button(action: {openSpecifiedURL(urlToOpen: buttonInfoAction);quitDialog(exitCode: 3)}, label: {
+                Button(action: {buttonAction(action: buttonInfoAction, exitCode: 3, executeShell: false)}, label: {
                     Text(appvars.buttonInfoDefault)
                     }
                 ).frame(minWidth: 36, alignment: .center)
             } else if CLOptionPresent(OptionName: CLOptions.buttonInfoTextOption) {
                 let buttonInfoText: String = CLOptionText(OptionName: CLOptions.buttonInfoTextOption, DefaultValue: appvars.buttonInfoDefault)
-                Button(action: {openSpecifiedURL(urlToOpen: buttonInfoAction);quitDialog(exitCode: 3)}, label: {
+                Button(action: {buttonAction(action: buttonInfoAction, exitCode: 3, executeShell: false)}, label: {
                     Text(buttonInfoText)
                     }
                 ).frame(minWidth: 36, alignment: .center)

--- a/dialog/UI/IconOverlayView.swift
+++ b/dialog/UI/IconOverlayView.swift
@@ -27,7 +27,7 @@ struct IconOverlayView: View {
         if overlayImagePath.starts(with: "http") {
             imgFromURL = true
         }
-        if overlayImagePath.hasSuffix(".app") {
+        if overlayImagePath.hasSuffix(".app") || overlayImagePath.hasSuffix("prefPane") {
             imgFromAPP = true
         }
         

--- a/dialog/UI/IconView.swift
+++ b/dialog/UI/IconView.swift
@@ -40,7 +40,7 @@ struct IconView: View {
             imgFromURL = true
         }
         
-        if messageUserImagePath.hasSuffix(".app") {
+        if messageUserImagePath.hasSuffix(".app") || messageUserImagePath.hasSuffix("prefPane") {
             imgFromAPP = true
         }
         

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -73,6 +73,12 @@ var helpText = """
                     Accepts URL
                     Default action if not specified is no action
                     Return code when actioned is 0
+    
+        --\(CLOptions.button1ShellActionOption.long) <command>
+                    << EXPERIMENTAL >>
+                    Runs the specified shell command using zsh
+                    Command input and output is not sanitised or checked.
+                    If your command fails, Dialog still exits 0
 
         -\(CLOptions.button2Option.short), --\(CLOptions.button2Option.long)
                     Displays button2 with default label of "\(appvars.button2Default)"
@@ -195,6 +201,7 @@ struct CLOptions {
     static let bannerImage              = (long: String("bannerimage"),       short: String("n"))  // -n
     static let button1TextOption        = (long: String("button1text"),       short: String(""))
     static let button1ActionOption      = (long: String("button1action"),     short: String(""))
+    static let button1ShellActionOption = (long: String("button1shellaction"),short: String(""))
     static let button2TextOption        = (long: String("button2text"),       short: String(""))
     static let button2ActionOption      = (long: String("button2action"),     short: String(""))
     static let buttonInfoTextOption     = (long: String("infobuttontext"),    short: String(""))

--- a/dialog/extras/Processing.swift
+++ b/dialog/extras/Processing.swift
@@ -62,6 +62,36 @@ func openSpecifiedURL(urlToOpen: String) {
     }
 }
 
+func shell(_ command: String) -> String {
+    let task = Process()
+    let pipe = Pipe()
+    
+    task.standardOutput = pipe
+    task.standardError = pipe
+    task.arguments = ["-c", command]
+    task.launchPath = "/bin/zsh"
+    task.launch()
+    
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    let output = String(data: data, encoding: .utf8)!
+    
+    return output
+}
+
+func buttonAction(action: String, exitCode: Int32, executeShell: Bool) {
+    //let action: String = CLOptionText(OptionName: CLOptions.button1ActionOption, DefaultValue: "")
+    
+    if (action != "") {
+        if executeShell {
+            print(shell(action))
+        } else {
+            openSpecifiedURL(urlToOpen: action)
+        }
+    }
+    quitDialog(exitCode: exitCode)
+    //exit(0)
+}
+
 func getAppIcon(appPath : String, withSize : CGFloat) -> NSImage {
     // take application path and extracts the application icon and returns is as NSImage
     // Swift implimentation of the ObjC code used in SAP's nice "Icons" utility for extracting application icons


### PR DESCRIPTION
Experimental - execute shell command using button1ShellActionOption
Icons can now also be extracted from PreferencePane bundles

Changed:
moved buttonAvtion to an external function that can be re-used elsewhere.