### PR TITLE
Add Dropdown options and Command Line app.

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		4154C2FC25F76BDC00A3D373 /* dialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4154C2FB25F76BDC00A3D373 /* dialogUITests.swift */; };
 		416DED42261C5FE00049B6B5 /* FullscreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416DED41261C5FE00049B6B5 /* FullscreenView.swift */; };
 		417BF0BB260F1726009AD252 /* BannerImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417BF0BA260F1726009AD252 /* BannerImageView.swift */; };
+		418AE4232667A17A001E3423 /* DropdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418AE4222667A17A001E3423 /* DropdownView.swift */; };
 		41D81E5725F7929800D1F7E1 /* DialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E5625F7929800D1F7E1 /* DialogView.swift */; };
 		41D81E5C25F817BF00D1F7E1 /* ButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E5B25F817BF00D1F7E1 /* ButtonView.swift */; };
 		41D81E6C25F8209F00D1F7E1 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E6B25F8209F00D1F7E1 /* Options.swift */; };
@@ -67,6 +68,7 @@
 		4154C2FD25F76BDC00A3D373 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		416DED41261C5FE00049B6B5 /* FullscreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenView.swift; sourceTree = "<group>"; };
 		417BF0BA260F1726009AD252 /* BannerImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerImageView.swift; sourceTree = "<group>"; };
+		418AE4222667A17A001E3423 /* DropdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownView.swift; sourceTree = "<group>"; };
 		41D81E5625F7929800D1F7E1 /* DialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogView.swift; sourceTree = "<group>"; };
 		41D81E5B25F817BF00D1F7E1 /* ButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonView.swift; sourceTree = "<group>"; };
 		41D81E6B25F8209F00D1F7E1 /* Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 				4153784D2604B71800AA0E76 /* TitleView.swift */,
 				417BF0BA260F1726009AD252 /* BannerImageView.swift */,
 				41D81E5B25F817BF00D1F7E1 /* ButtonView.swift */,
+				418AE4222667A17A001E3423 /* DropdownView.swift */,
 				415378522604B79E00AA0E76 /* IconOverlayView.swift */,
 				416DED41261C5FE00049B6B5 /* FullscreenView.swift */,
 			);
@@ -342,6 +345,7 @@
 				417BF0BB260F1726009AD252 /* BannerImageView.swift in Sources */,
 				4153786C2604BF1A00AA0E76 /* MessageContentView.swift in Sources */,
 				416DED42261C5FE00049B6B5 /* FullscreenView.swift in Sources */,
+				418AE4232667A17A001E3423 /* DropdownView.swift in Sources */,
 				41D81E5725F7929800D1F7E1 /* DialogView.swift in Sources */,
 				4154C2E025F76BDB00A3D373 /* ContentView.swift in Sources */,
 				41D81E5C25F817BF00D1F7E1 /* ButtonView.swift in Sources */,
@@ -522,7 +526,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -549,7 +553,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -103,7 +103,6 @@
 		41D81E7025F845D200D1F7E1 /* appVaribles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = appVaribles.swift; sourceTree = "<group>"; };
 		41D81E7825F870A500D1F7E1 /* Processing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Processing.swift; sourceTree = "<group>"; };
 		41FB6480268070CF00A54C3E /* dialog */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = dialog; sourceTree = BUILT_PRODUCTS_DIR; };
-		41FB6482268070CF00A54C3E /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -232,7 +231,6 @@
 		41FB6481268070CF00A54C3E /* dialog */ = {
 			isa = PBXGroup;
 			children = (
-				41FB6482268070CF00A54C3E /* main.swift */,
 			);
 			path = dialog;
 			sourceTree = "<group>";
@@ -617,7 +615,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.0b2;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -644,7 +642,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.0b2;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -735,11 +733,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = PWA5E9TQ59;
+				DEVELOPMENT_TEAM = N8GJ2Y5Z9T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/dialog/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.3.0b1;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogcli;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -750,11 +748,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = PWA5E9TQ59;
+				DEVELOPMENT_TEAM = N8GJ2Y5Z9T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/dialog/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.3.0b1;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogcli;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -526,7 +526,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.0b2;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -553,7 +553,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.0b2;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialog;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -27,6 +27,22 @@
 		41D81E6C25F8209F00D1F7E1 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E6B25F8209F00D1F7E1 /* Options.swift */; };
 		41D81E7125F845D200D1F7E1 /* appVaribles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E7025F845D200D1F7E1 /* appVaribles.swift */; };
 		41D81E7925F870A500D1F7E1 /* Processing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E7825F870A500D1F7E1 /* Processing.swift */; };
+		41FB64872680855300A54C3E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4154C2DF25F76BDB00A3D373 /* ContentView.swift */; };
+		41FB64882680855300A54C3E /* DialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E5625F7929800D1F7E1 /* DialogView.swift */; };
+		41FB64892680855300A54C3E /* MessageContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4153786B2604BF1A00AA0E76 /* MessageContentView.swift */; };
+		41FB648A2680855300A54C3E /* IconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4153785D2604B81300AA0E76 /* IconView.swift */; };
+		41FB648B2680855300A54C3E /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4153784D2604B71800AA0E76 /* TitleView.swift */; };
+		41FB648C2680855300A54C3E /* BannerImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 417BF0BA260F1726009AD252 /* BannerImageView.swift */; };
+		41FB648D2680855300A54C3E /* ButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E5B25F817BF00D1F7E1 /* ButtonView.swift */; };
+		41FB648E2680855300A54C3E /* DropdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418AE4222667A17A001E3423 /* DropdownView.swift */; };
+		41FB648F2680855300A54C3E /* IconOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 415378522604B79E00AA0E76 /* IconOverlayView.swift */; };
+		41FB64902680855300A54C3E /* FullscreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416DED41261C5FE00049B6B5 /* FullscreenView.swift */; };
+		41FB64912680855300A54C3E /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E6B25F8209F00D1F7E1 /* Options.swift */; };
+		41FB64922680855300A54C3E /* Processing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E7825F870A500D1F7E1 /* Processing.swift */; };
+		41FB64932680855300A54C3E /* License.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41110A2725F9E79E008171D2 /* License.swift */; };
+		41FB64942680855300A54C3E /* StringProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4153783126001A0900AA0E76 /* StringProcessing.swift */; };
+		41FB64952680855300A54C3E /* dialogApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4154C2DD25F76BDB00A3D373 /* dialogApp.swift */; };
+		41FB64962680855300A54C3E /* appVaribles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41D81E7025F845D200D1F7E1 /* appVaribles.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +61,18 @@
 			remoteInfo = dialog;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		41FB647E268070CF00A54C3E /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		41110A2725F9E79E008171D2 /* License.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = License.swift; sourceTree = "<group>"; };
@@ -74,6 +102,8 @@
 		41D81E6B25F8209F00D1F7E1 /* Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
 		41D81E7025F845D200D1F7E1 /* appVaribles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = appVaribles.swift; sourceTree = "<group>"; };
 		41D81E7825F870A500D1F7E1 /* Processing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Processing.swift; sourceTree = "<group>"; };
+		41FB6480268070CF00A54C3E /* dialog */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = dialog; sourceTree = BUILT_PRODUCTS_DIR; };
+		41FB6482268070CF00A54C3E /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,6 +128,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		41FB647D268070CF00A54C3E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -107,6 +144,7 @@
 				4154C2DC25F76BDB00A3D373 /* dialog */,
 				4154C2EF25F76BDC00A3D373 /* dialogTests */,
 				4154C2FA25F76BDC00A3D373 /* dialogUITests */,
+				41FB6481268070CF00A54C3E /* dialog */,
 				4154C2DB25F76BDB00A3D373 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -117,6 +155,7 @@
 				4154C2DA25F76BDB00A3D373 /* Dialog.app */,
 				4154C2EC25F76BDC00A3D373 /* dialogTests.xctest */,
 				4154C2F725F76BDC00A3D373 /* dialogUITests.xctest */,
+				41FB6480268070CF00A54C3E /* dialog */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -190,6 +229,14 @@
 			path = UI;
 			sourceTree = "<group>";
 		};
+		41FB6481268070CF00A54C3E /* dialog */ = {
+			isa = PBXGroup;
+			children = (
+				41FB6482268070CF00A54C3E /* main.swift */,
+			);
+			path = dialog;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -247,13 +294,30 @@
 			productReference = 4154C2F725F76BDC00A3D373 /* dialogUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		41FB647F268070CF00A54C3E /* dialog */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 41FB6486268070CF00A54C3E /* Build configuration list for PBXNativeTarget "dialog" */;
+			buildPhases = (
+				41FB647C268070CF00A54C3E /* Sources */,
+				41FB647D268070CF00A54C3E /* Frameworks */,
+				41FB647E268070CF00A54C3E /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = dialog;
+			productName = dialog;
+			productReference = 41FB6480268070CF00A54C3E /* dialog */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		4154C2D225F76BDB00A3D373 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1240;
+				LastSwiftUpdateCheck = 1250;
 				LastUpgradeCheck = 1240;
 				TargetAttributes = {
 					4154C2D925F76BDB00A3D373 = {
@@ -266,6 +330,9 @@
 					4154C2F625F76BDC00A3D373 = {
 						CreatedOnToolsVersion = 12.4;
 						TestTargetID = 4154C2D925F76BDB00A3D373;
+					};
+					41FB647F268070CF00A54C3E = {
+						CreatedOnToolsVersion = 12.5;
 					};
 				};
 			};
@@ -285,6 +352,7 @@
 				4154C2D925F76BDB00A3D373 /* Dialog */,
 				4154C2EB25F76BDC00A3D373 /* dialogTests */,
 				4154C2F625F76BDC00A3D373 /* dialogUITests */,
+				41FB647F268070CF00A54C3E /* dialog */,
 			);
 		};
 /* End PBXProject section */
@@ -372,6 +440,29 @@
 			buildActionMask = 2147483647;
 			files = (
 				4154C2FC25F76BDC00A3D373 /* dialogUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		41FB647C268070CF00A54C3E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				41FB64872680855300A54C3E /* ContentView.swift in Sources */,
+				41FB64882680855300A54C3E /* DialogView.swift in Sources */,
+				41FB64892680855300A54C3E /* MessageContentView.swift in Sources */,
+				41FB648A2680855300A54C3E /* IconView.swift in Sources */,
+				41FB648B2680855300A54C3E /* TitleView.swift in Sources */,
+				41FB648C2680855300A54C3E /* BannerImageView.swift in Sources */,
+				41FB648D2680855300A54C3E /* ButtonView.swift in Sources */,
+				41FB648E2680855300A54C3E /* DropdownView.swift in Sources */,
+				41FB648F2680855300A54C3E /* IconOverlayView.swift in Sources */,
+				41FB64902680855300A54C3E /* FullscreenView.swift in Sources */,
+				41FB64912680855300A54C3E /* Options.swift in Sources */,
+				41FB64922680855300A54C3E /* Processing.swift in Sources */,
+				41FB64932680855300A54C3E /* License.swift in Sources */,
+				41FB64942680855300A54C3E /* StringProcessing.swift in Sources */,
+				41FB64952680855300A54C3E /* dialogApp.swift in Sources */,
+				41FB64962680855300A54C3E /* appVaribles.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -640,6 +731,36 @@
 			};
 			name = Release;
 		};
+		41FB6484268070CF00A54C3E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = PWA5E9TQ59;
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/dialog/Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MARKETING_VERSION = 1.3.0b1;
+				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogcli;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		41FB6485268070CF00A54C3E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = PWA5E9TQ59;
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/dialog/Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MARKETING_VERSION = 1.3.0b1;
+				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogcli;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -675,6 +796,15 @@
 			buildConfigurations = (
 				4154C30725F76BDC00A3D373 /* Debug */,
 				4154C30825F76BDC00A3D373 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		41FB6486268070CF00A54C3E /* Build configuration list for PBXNativeTarget "dialog" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				41FB6484268070CF00A54C3E /* Debug */,
+				41FB6485268070CF00A54C3E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/dialog.xcodeproj/xcuserdata/rea094.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/dialog.xcodeproj/xcuserdata/rea094.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,7 +12,30 @@
 		<key>dialog.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
+		</dict>
+	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>4154C2D925F76BDB00A3D373</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>4154C2EB25F76BDC00A3D373</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>4154C2F625F76BDC00A3D373</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>41FB647F268070CF00A54C3E</key>
+		<dict>
+			<key>primary</key>
+			<true/>
 		</dict>
 	</dict>
 </dict>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1303</string>
+	<string>1306</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1308</string>
+	<string>1312</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1307</string>
+	<string>1308</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1273</string>
+	<string>1282</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1306</string>
+	<string>1307</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1282</string>
+	<string>1303</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/Info.plist
+++ b/dialog/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1209</string>
+	<string>1273</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/dialog/UI/BannerImageView.swift
+++ b/dialog/UI/BannerImageView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct BannerImageView: View {
     
-    var BannerImageOption: String = CLOptionText(OptionName: CLOptions.bannerImage, DefaultValue: "")
+    var BannerImageOption: String = CLOptionText(OptionName: CLOptions.bannerImage)
 
     var body: some View {
         VStack {

--- a/dialog/UI/ButtonView.swift
+++ b/dialog/UI/ButtonView.swift
@@ -15,10 +15,10 @@ struct ButtonView: View {
     
     init() {
         if CLOptionPresent(OptionName: CLOptions.button1ShellActionOption) {
-            button1action = CLOptionText(OptionName: CLOptions.button1ShellActionOption , DefaultValue: "")
+            button1action = CLOptionText(OptionName: CLOptions.button1ShellActionOption)
             buttonShellAction = true
         } else if CLOptionPresent(OptionName: CLOptions.button1ActionOption) {
-            button1action = CLOptionText(OptionName: CLOptions.button1ActionOption, DefaultValue: "")
+            button1action = CLOptionText(OptionName: CLOptions.button1ActionOption)
         }
     }
     

--- a/dialog/UI/ContentView.swift
+++ b/dialog/UI/ContentView.swift
@@ -26,17 +26,17 @@ struct ContentView: View {
     
     var bannerImagePresent = false
     var bannerAdjustment       = CGFloat(5)
-    
+        
     var body: some View {
         VStack {
             if bannerImagePresent {
-            HStack {
-                BannerImageView()
-                    .frame(width: appvars.windowWidth, height: appvars.bannerHeight-bannerAdjustment, alignment: .topLeading)
-                    //.border(Color.green)
-                    .clipped()
-            }
-            .offset(y: appvars.bannerOffset)
+                HStack {
+                    BannerImageView()
+                        .frame(width: appvars.windowWidth, height: appvars.bannerHeight-bannerAdjustment, alignment: .topLeading)
+                        //.border(Color.green)
+                        .clipped()
+                }
+                .offset(y: appvars.bannerOffset)
             }
             // Dialog title
             HStack(alignment: .top){
@@ -57,13 +57,15 @@ struct ContentView: View {
             
             // Dialog content including message and image if visible
             HStack(alignment: .top) {
-                DialogView()
-                    .frame(width: (appvars.windowWidth-30), height: (appvars.windowHeight * appvars.dialogContentScale * appvars.scaleFactor))
-                    //.border(Color.green)
+                VStack {
+                    DialogView()
+                        .frame(width: (appvars.windowWidth-30), height: (appvars.windowHeight * appvars.dialogContentScale * appvars.scaleFactor))
+                        //.border(Color.green)
+                }
             }.frame(alignment: .topLeading)
             .border(appvars.debugBorderColour) //debuging
             //.border(Color.red) //debuging
-
+            
             
             // Buttons
             Spacer() // force button to the bottom
@@ -73,6 +75,7 @@ struct ContentView: View {
                     MoreInfoButton()
                 }
                 Spacer()
+                //DropdownView().padding(20)
                 ButtonView()
                     //.frame(alignment: .bottom)
             }

--- a/dialog/UI/DialogView.swift
+++ b/dialog/UI/DialogView.swift
@@ -32,7 +32,6 @@ struct DialogView: View {
                 VStack(alignment: .center) {
                     //TitleView()
                     MessageContent()
-                        
                 }
             }
             

--- a/dialog/UI/DropdownView.swift
+++ b/dialog/UI/DropdownView.swift
@@ -26,14 +26,12 @@ struct DropdownView: View {
             showDropdown = true
             dropdownCLValues = CLOptionText(OptionName: CLOptions.dropdownValues)
             dropdownValues = dropdownCLValues.components(separatedBy: ",")
-            dropdownValues = dropdownValues.map { $0.trimmingCharacters(in: .whitespaces) }
+            dropdownValues = dropdownValues.map { $0.trimmingCharacters(in: .whitespaces) } // trim out any whitespace from the values if there were spaces before after the comma
             dropdownTitle = CLOptionText(OptionName: CLOptions.dropdownTitle)
         }
         if CLOptionPresent(OptionName: CLOptions.dropdownDefault) && CLOptionText(OptionName: CLOptions.dropdownValues).contains(CLOptionText(OptionName: CLOptions.dropdownDefault)) {
             appvars.selectedOption = selectedOption
         }
-        
-        //.trimmingCharacters(in: .whitespacesAndNewlines)
     }
     
     func updateSelectedOption() {
@@ -43,16 +41,18 @@ struct DropdownView: View {
     var body: some View {
         if showDropdown {
             HStack {
+                // we could print the title as part of the picker control but then we don't get easy access to swiftui text formatting
+                // so we print it seperatly and use a blank value in the picker
                 Text(dropdownTitle).bold()
                 Picker("", selection: $selectedOption)
                 {
                     ForEach(dropdownValues, id: \.self) {
                         Text($0)
                     }
-                }.frame(width: 200)
+                }
                 .pickerStyle(DefaultPickerStyle())
                 .onChange(of: selectedOption) { _ in
-                            //print(selectedOption)
+                            //update appvars with the option that was selected. this will be printed to stdout on exit
                             appvars.selectedOption = selectedOption
                         }
                 

--- a/dialog/UI/DropdownView.swift
+++ b/dialog/UI/DropdownView.swift
@@ -63,7 +63,7 @@ struct DropdownView: View {
                             //appvars.selectedIndex += 1  // removed by popular opinion
                         }
                 
-            }
+            }.padding(.horizontal)
         }
     }
     

--- a/dialog/UI/DropdownView.swift
+++ b/dialog/UI/DropdownView.swift
@@ -12,8 +12,9 @@ import Combine
 
 struct DropdownView: View {
     
-    @State var selectedOption = CLOptionText(OptionName: CLOptions.dropdownDefault, DefaultValue: "")
+    @State var selectedOption = CLOptionText(OptionName: CLOptions.dropdownDefault)
     //@Binding var selectedOption: String = CLOptionText(OptionName: CLOptions.dropdownDefault, DefaultValue: "")
+    var selectedIndex = -1
     var dropdownValues = [""]
     var dropdownCLValues: String = ""
     var dropdownTitle: String = ""
@@ -31,6 +32,8 @@ struct DropdownView: View {
         }
         if CLOptionPresent(OptionName: CLOptions.dropdownDefault) && CLOptionText(OptionName: CLOptions.dropdownValues).contains(CLOptionText(OptionName: CLOptions.dropdownDefault)) {
             appvars.selectedOption = selectedOption
+            appvars.selectedIndex = dropdownValues.firstIndex {$0 == selectedOption} ?? -1
+            //appvars.selectedIndex += 1
         }
     }
     
@@ -43,7 +46,9 @@ struct DropdownView: View {
             HStack {
                 // we could print the title as part of the picker control but then we don't get easy access to swiftui text formatting
                 // so we print it seperatly and use a blank value in the picker
-                Text(dropdownTitle).bold()
+                Text(dropdownTitle)
+                    .bold()
+                    .font(.system(size: 15))
                 Picker("", selection: $selectedOption)
                 {
                     ForEach(dropdownValues, id: \.self) {
@@ -54,6 +59,8 @@ struct DropdownView: View {
                 .onChange(of: selectedOption) { _ in
                             //update appvars with the option that was selected. this will be printed to stdout on exit
                             appvars.selectedOption = selectedOption
+                            appvars.selectedIndex = dropdownValues.firstIndex {$0 == selectedOption} ?? -1
+                            //appvars.selectedIndex += 1  // removed by popular opinion
                         }
                 
             }

--- a/dialog/UI/DropdownView.swift
+++ b/dialog/UI/DropdownView.swift
@@ -1,0 +1,64 @@
+//
+//  DropdownView.swift
+//  Dialog
+//
+//  Created by Reardon, Bart (IM&T, Yarralumla) on 2/6/21.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+
+
+struct DropdownView: View {
+    
+    @State var selectedOption = CLOptionText(OptionName: CLOptions.dropdownDefault, DefaultValue: "")
+    //@Binding var selectedOption: String = CLOptionText(OptionName: CLOptions.dropdownDefault, DefaultValue: "")
+    var dropdownValues = [""]
+    var dropdownCLValues: String = ""
+    var dropdownTitle: String = ""
+    
+    var showDropdown: Bool = false
+    var defaultValue: String = ""
+    
+    init() {
+        if CLOptionPresent(OptionName: CLOptions.dropdownValues) {
+            showDropdown = true
+            dropdownCLValues = CLOptionText(OptionName: CLOptions.dropdownValues)
+            dropdownValues = dropdownCLValues.components(separatedBy: ",")
+            dropdownValues = dropdownValues.map { $0.trimmingCharacters(in: .whitespaces) }
+            dropdownTitle = CLOptionText(OptionName: CLOptions.dropdownTitle)
+        }
+        if CLOptionPresent(OptionName: CLOptions.dropdownDefault) && CLOptionText(OptionName: CLOptions.dropdownValues).contains(CLOptionText(OptionName: CLOptions.dropdownDefault)) {
+            appvars.selectedOption = selectedOption
+        }
+        
+        //.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    
+    func updateSelectedOption() {
+        appvars.selectedOption = self.selectedOption
+    }
+    
+    var body: some View {
+        if showDropdown {
+            HStack {
+                Text(dropdownTitle).bold()
+                Picker("", selection: $selectedOption)
+                {
+                    ForEach(dropdownValues, id: \.self) {
+                        Text($0)
+                    }
+                }.frame(width: 200)
+                .pickerStyle(DefaultPickerStyle())
+                .onChange(of: selectedOption) { _ in
+                            //print(selectedOption)
+                            appvars.selectedOption = selectedOption
+                        }
+                
+            }
+        }
+    }
+    
+    
+}

--- a/dialog/UI/FullscreenView.swift
+++ b/dialog/UI/FullscreenView.swift
@@ -40,7 +40,7 @@ struct FullscreenView: View {
     var minScreenHeightToDisplayBanner:CGFloat = 1000
     var messageTextLineSpacing:CGFloat = 20
     
-    var BannerImageOption: String = CLOptionText(OptionName: CLOptions.bannerImage, DefaultValue: "")
+    var BannerImageOption: String = CLOptionText(OptionName: CLOptions.bannerImage)
     
     var debugColour: Color = Color.clear
      

--- a/dialog/UI/IconOverlayView.swift
+++ b/dialog/UI/IconOverlayView.swift
@@ -12,7 +12,7 @@ struct IconOverlayView: View {
     let overlayWidth: CGFloat?
     let overlayHeight: CGFloat?
     
-    let overlayImagePath: String = CLOptionText(OptionName: CLOptions.overlayIconOption, DefaultValue: "")
+    let overlayImagePath: String = CLOptionText(OptionName: CLOptions.overlayIconOption)
     var imgFromURL: Bool = false
     var imgFromAPP: Bool = false
     

--- a/dialog/UI/MessageContentView.swift
+++ b/dialog/UI/MessageContentView.swift
@@ -35,6 +35,8 @@ struct MessageContent: View {
         VStack {
             Text(messageContentOption)
                 .font(.system(size: 20))
+                DropdownView()
+                    .frame(width: viewWidth-50, alignment: .leading)
         }
         .frame(width: viewWidth-50, height: viewHeight, alignment: theAllignment)
         .padding(15)

--- a/dialog/UI/MessageContentView.swift
+++ b/dialog/UI/MessageContentView.swift
@@ -35,8 +35,9 @@ struct MessageContent: View {
         VStack {
             Text(messageContentOption)
                 .font(.system(size: 20))
+                Spacer()
                 DropdownView()
-                    .frame(width: viewWidth-50, alignment: .leading)
+                    .frame(width: viewWidth-50, alignment: .bottomLeading)
         }
         .frame(width: viewWidth-50, height: viewHeight, alignment: theAllignment)
         .padding(15)

--- a/dialog/UI/MessageContentView.swift
+++ b/dialog/UI/MessageContentView.swift
@@ -41,7 +41,7 @@ struct MessageContent: View {
                 .font(.system(size: 20))
                 Spacer()
                 DropdownView()
-                    .frame(width: viewWidth-50, alignment: .bottomLeading)
+                    //.frame(width: viewWidth-50, alignment: .bottomLeading)
         }
         .frame(width: viewWidth-50, height: viewHeight, alignment: theAllignment)
         .padding(15)

--- a/dialog/UI/MessageContentView.swift
+++ b/dialog/UI/MessageContentView.swift
@@ -31,8 +31,12 @@ struct MessageContent: View {
     let messageContentOption: String = CLOptionText(OptionName: CLOptions.messageOption, DefaultValue: appvars.messageDefault)
     let theAllignment: Alignment = .topLeading
     
+    
+    //@State var thing: String = "" //testing
+    
     var body: some View {
         VStack {
+            //TextField("Enter thing...", text: $thing)
             Text(messageContentOption)
                 .font(.system(size: 20))
                 Spacer()

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -106,6 +106,15 @@ var helpText = """
                     Set the action to take.
                     Accepts URL
                     Default action if not specified is no action
+    
+        --\(CLOptions.dropdownTitle.long) <text>
+                    Title for dropdown selection
+    
+        --\(CLOptions.dropdownValues.long) <text><csv>
+                    List of values to be displayed in the dropdown
+    
+        --\(CLOptions.dropdownDefault.long) <text>
+                    Defult option to be selected (must match one of the items in the list)
 
         -\(CLOptions.lockWindow.short), --\(CLOptions.lockWindow.long)
                     Let window me moved around the screen. Default is not moveable
@@ -171,6 +180,9 @@ struct AppVariables {
     
     var debugBorderColour               = Color.clear
     
+    var selectedOption                  = ""
+    var selectedIndex                   = Int32(0)
+    
     // exit codes and error messages
     var exit201                         = (code: Int32(201), message: String("ERROR: Image resource cannot be found :"))
     var exit202                         = (code: Int32(202), message: String("ERROR: File not found :"))
@@ -206,6 +218,9 @@ struct CLOptions {
     static let button2ActionOption      = (long: String("button2action"),     short: String(""))
     static let buttonInfoTextOption     = (long: String("infobuttontext"),    short: String(""))
     static let buttonInfoActionOption   = (long: String("infobuttonaction"),  short: String(""))
+    static let dropdownTitle            = (long: String("selecttitle"),       short: String(""))
+    static let dropdownValues           = (long: String("selectvalues"),      short: String(""))
+    static let dropdownDefault          = (long: String("selectdefault"),     short: String(""))
 
    
     // command line options that take no additional parameters

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -152,7 +152,7 @@ var helpText = """
 
 struct AppVariables {
 
-    var cliversion                      = String("1.3.0b1")
+    var cliversion                      = String("1.3.0")
     
     // message default strings
     var titleDefault                    = String("An Important Message")

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -152,6 +152,7 @@ var helpText = """
 
 struct AppVariables {
 
+    var cliversion                      = String("1.3.0b1")
     
     // message default strings
     var titleDefault                    = String("An Important Message")

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -111,10 +111,22 @@ var helpText = """
                     Title for dropdown selection
     
         --\(CLOptions.dropdownValues.long) <text><csv>
-                    List of values to be displayed in the dropdown
+                    List of values to be displayed in the dropdown, specivied in CSV format
+                    e.g. "Option 1,Option 2,Option 3"
     
         --\(CLOptions.dropdownDefault.long) <text>
-                    Defult option to be selected (must match one of the items in the list)
+                    Default option to be selected (must match one of the items in the list)
+    
+                    If specified, the selected option will be sent to stdout in two forms:
+                      SelectedOption - Outputs the text of the option seelcted
+                      SelectedIndex  - Outputs the index of the option selected, starting at 0
+    
+                      example output b:
+                        SelectedOption: Option 1
+                        SelectedIndex: 0
+    
+                    Output of select items is only shown if Dialog's exit code is 0
+
 
         -\(CLOptions.lockWindow.short), --\(CLOptions.lockWindow.long)
                     Let window me moved around the screen. Default is not moveable
@@ -181,7 +193,7 @@ struct AppVariables {
     var debugBorderColour               = Color.clear
     
     var selectedOption                  = ""
-    var selectedIndex                   = Int32(0)
+    var selectedIndex                   = 0
     
     // exit codes and error messages
     var exit201                         = (code: Int32(201), message: String("ERROR: Image resource cannot be found :"))

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -23,6 +23,12 @@ struct dialogApp: App {
     
     init () {
         
+        // Correct feng shui so the app accepts keyboard input
+        // from https://stackoverflow.com/questions/58872398/what-is-the-minimally-viable-gui-for-command-line-swift-scripts
+        let app = NSApplication.shared
+        app.setActivationPolicy(.regular)
+        
+        
         // process command line options that just display info and exit before we show the main window
         if (CLOptionPresent(OptionName: CLOptions.helpOption) || CommandLine.arguments.count == 1) {
             print(helpText)

--- a/dialog/extras/Options.swift
+++ b/dialog/extras/Options.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // Returns the option text for a given command line option
 
-func CLOptionText(OptionName: (long: String, short: String), DefaultValue: String) -> String {
+func CLOptionText(OptionName: (long: String, short: String), DefaultValue: String? = "") -> String {
     // Determine if argument is present.
     var CLOptionTextValue = ""
         
@@ -24,13 +24,13 @@ func CLOptionText(OptionName: (long: String, short: String), DefaultValue: Strin
             CLOptionTextValue = CommandLine.arguments[valueIndex]
             if (CLOptionTextValue.starts(with: "-")) {
                 print("Argument \(CommandLine.arguments[commandIndex]) was not passed a value.")
-                CLOptionTextValue = DefaultValue
+                CLOptionTextValue = DefaultValue ?? ""
             } else {
                 CLOptionTextValue = CLOptionTextValue.replacingOccurrences(of:"\\n", with:"\n")
             }
         }
     } else {
-        CLOptionTextValue = DefaultValue
+        CLOptionTextValue = DefaultValue ?? ""
     }
     //print("\(OptionName) - \(CLOptionTextValue)")
     return CLOptionTextValue

--- a/dialog/extras/Processing.swift
+++ b/dialog/extras/Processing.swift
@@ -10,6 +10,9 @@ import AppKit
 import SystemConfiguration
 import SwiftUI
 
+class stdOutput: ObservableObject {
+    @Published var selectedOption: String = ""
+}
 
 func getImageFromPath(fileImagePath: String, imgWidth: CGFloat? = .infinity, imgHeight: CGFloat? = .infinity, returnErrorImage: Bool? = false) -> NSImage {
     // accept image as local file path or as URL and return NSImage
@@ -123,6 +126,9 @@ func quitDialog(exitCode: Int32, exitMessage: String? = "") {
     if exitMessage != "" {
         print(exitCode)
         print("\(exitMessage!)")
+    }
+    if appvars.selectedOption != "" {
+        print("SelectedOption: \(appvars.selectedOption)")
     }
     exit(exitCode)
 }

--- a/dialog/extras/Processing.swift
+++ b/dialog/extras/Processing.swift
@@ -131,10 +131,11 @@ func quitDialog(exitCode: Int32, exitMessage: String? = "") {
     if exitCode == 0 {
         if appvars.selectedOption != "" {
             print("SelectedOption: \(appvars.selectedOption)")
-        }
-        if CLOptionPresent(OptionName: CLOptions.dropdownDefault) && appvars.selectedIndex >= 0 {
             print("SelectedIndex: \(appvars.selectedIndex)")
         }
+        //if CLOptionPresent(OptionName: CLOptions.dropdownDefault) || appvars.selectedIndex >= 0 {
+        //    print("SelectedIndex: \(appvars.selectedIndex)")
+        //}
     }
     exit(exitCode)
 }

--- a/dialog/extras/Processing.swift
+++ b/dialog/extras/Processing.swift
@@ -115,7 +115,7 @@ func printVersionString() -> Void {
 }
 
 func getVersionString() -> String {
-    var appVersion: String = "0.0"
+    var appVersion: String = appvars.cliversion
     if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
         appVersion = version
     }

--- a/dialog/extras/Processing.swift
+++ b/dialog/extras/Processing.swift
@@ -127,8 +127,14 @@ func quitDialog(exitCode: Int32, exitMessage: String? = "") {
         print(exitCode)
         print("\(exitMessage!)")
     }
-    if appvars.selectedOption != "" {
-        print("SelectedOption: \(appvars.selectedOption)")
+    // only print if exit code os 0
+    if exitCode == 0 {
+        if appvars.selectedOption != "" {
+            print("SelectedOption: \(appvars.selectedOption)")
+        }
+        if CLOptionPresent(OptionName: CLOptions.dropdownDefault) && appvars.selectedIndex >= 0 {
+            print("SelectedIndex: \(appvars.selectedIndex)")
+        }
     }
     exit(exitCode)
 }


### PR DESCRIPTION
Yeah, two in one. 1.2 was rolled into 1.3 prior to a PR. Is what it is.

1.2 -> added option for specifying a dropdown box that a user can pick from
1.3 -> compiled target to a cli only binary that can be placed in `usr/local/bin`. This may be the only option moving forward, or now I'm releasing the cli version and the app bundle.