### PR TITLE
Fix fullscreen and some other cleanup

### DIFF
--- a/dialog/UI/ButtonView.swift
+++ b/dialog/UI/ButtonView.swift
@@ -28,27 +28,30 @@ struct ButtonView: View {
             if CLOptionPresent(OptionName: CLOptions.button2Option){
                 Button(action: {quitDialog(exitCode: 2)}, label: {
                     Text(appvars.button2Default)
+                        .frame(minWidth: 40, alignment: .center)
                     }
-                ).frame(minWidth: 36, alignment: .center)
+                )
                 .keyboardShortcut(.cancelAction)
             } else if CLOptionPresent(OptionName: CLOptions.button2TextOption) {
                 let button2Text: String = CLOptionText(OptionName: CLOptions.button2TextOption, DefaultValue: appvars.button2Default)
                 Button(action: {quitDialog(exitCode: 2)}, label: {
                     Text(button2Text)
+                        .frame(minWidth: 40, alignment: .center)
                     }
-                ).frame(minWidth: 36, alignment: .center)
+                )
                 .keyboardShortcut(.cancelAction)
             }
         }
         // default button aka button 1
         let button1Text: String = CLOptionText(OptionName: CLOptions.button1TextOption, DefaultValue: appvars.button1Default)
-        HStack {
+        //HStack {
             Button(action: {buttonAction(action: self.button1action, exitCode: 0, executeShell: self.buttonShellAction)}, label: {
                 Text(button1Text)
+                    .frame(minWidth: 40, alignment: .center)
                 }
-            ).frame(minWidth: 36, alignment: .center)
+            )//.frame(minWidth: 36, alignment: .center)
             .keyboardShortcut(.defaultAction)
-        }
+        //}
     }
 }
 
@@ -61,14 +64,16 @@ struct MoreInfoButton: View {
             if CLOptionPresent(OptionName: CLOptions.infoButtonOption) {
                 Button(action: {buttonAction(action: buttonInfoAction, exitCode: 3, executeShell: false)}, label: {
                     Text(appvars.buttonInfoDefault)
+                        .frame(minWidth: 40, alignment: .center)
                     }
-                ).frame(minWidth: 36, alignment: .center)
+                )
             } else if CLOptionPresent(OptionName: CLOptions.buttonInfoTextOption) {
                 let buttonInfoText: String = CLOptionText(OptionName: CLOptions.buttonInfoTextOption, DefaultValue: appvars.buttonInfoDefault)
                 Button(action: {buttonAction(action: buttonInfoAction, exitCode: 3, executeShell: false)}, label: {
                     Text(buttonInfoText)
+                        .frame(minWidth: 40, alignment: .center)
                     }
-                ).frame(minWidth: 36, alignment: .center)
+                )
             }
             Spacer()
         }

--- a/dialog/UI/FullscreenView.swift
+++ b/dialog/UI/FullscreenView.swift
@@ -72,8 +72,13 @@ struct FullscreenView: View {
             //maxBannerHeight = 150
         }
         
-        //debugColour = Color.red
+        debugColour = Color.red
         
+        if appvars.titleFontColour == Color.primary {
+            appvars.titleFontColour = Color.white
+            
+        }
+                
     }
             
     public func showFullScreen() {
@@ -98,39 +103,35 @@ struct FullscreenView: View {
         
         VStack{
             // banner image vstack
-            VStack{
-                if CLOptionPresent(OptionName: CLOptions.bannerImage) {
-                    Image(nsImage: getImageFromPath(fileImagePath: BannerImageOption))
-                        .resizable()
-                        .clipShape(RoundedRectangle(cornerRadius: 15))
-                        .scaledToFit()
-                        .frame(maxWidth: maxBannerWidth, maxHeight: maxBannerHeight)
-                    // Horozontal Line
-                    VStack{
-                        Rectangle()
-                            .fill(Color.gray.opacity(0.5))
-                            .frame(height: 2)
-                    }
-                    .frame(width: (maxBannerWidth))
-                    .padding(.vertical,20)
-                    .border(debugColour)
+            if CLOptionPresent(OptionName: CLOptions.bannerImage) {
+                Image(nsImage: getImageFromPath(fileImagePath: BannerImageOption))
+                    .resizable()
+                    .clipShape(RoundedRectangle(cornerRadius: 15))
+                    .scaledToFit()
+                    .frame(maxWidth: maxBannerWidth, maxHeight: maxBannerHeight)
+                // Horozontal Line
+                VStack{
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.5))
+                        .frame(height: 2)
                 }
-            }.padding(bannerPadding) //padding for the top of the display
-            .border(debugColour)
+                .frame(width: (maxBannerWidth))
+                .padding(.vertical,20)
+                //.border(debugColour)
+            }
             
             // title vstack
-            VStack{
-                HStack {
-                    Spacer()
-                    Text(TitleViewOption)
-                        .foregroundColor(.white)
-                        .bold()
-                        .font(.system(size: titleContentFontSize))
-                    Spacer()
-                }
-                .border(debugColour)
+            HStack {
+                // the spacers in this section push the title and thus the full screen area across the width of the display
+                Spacer()
+                Text(TitleViewOption)
+                    .foregroundColor(appvars.titleFontColour)
+                    .bold()
+                    .font(.system(size: titleContentFontSize, weight: appvars.titleFontWeight))
+                    .multilineTextAlignment(.center)
+                Spacer()
             }
-            //.border(Color.blue)
+            //.border(Color.green)
             
             // icon and message vstack group
             VStack {
@@ -138,14 +139,14 @@ struct FullscreenView: View {
                 VStack {
                     if CLOptionPresent(OptionName: CLOptions.iconOption) {
                         IconView()
-                            .frame(maxHeight: appvars.imageHeight*iconImageScaleFactor, alignment: .center)
+                            //.frame(maxHeight: appvars.imageHeight*iconImageScaleFactor, alignment: .center)
                             //.background(Color.white)
                     } else {
                         VStack{}.padding(emptyStackPadding)
                     }
                 }
                 .padding(40)
-                .border(debugColour)
+                //.border(Color.orange)
                 
                 // message vstack
                 VStack() {
@@ -156,13 +157,14 @@ struct FullscreenView: View {
                         .lineLimit(12)
                         .lineSpacing(messageTextLineSpacing)
                         
-                }.border(debugColour)
+                }
+                //.border(debugColour)
                 .padding(10)
                 .frame(maxHeight: .infinity, alignment: .center) // setting to .infinity should make the message content take up the remainder of the screen
             }
             .padding(.horizontal, 20) // total padding for the icon/message group
             .padding(.vertical, 50)
-            .border(debugColour)
+            //.border(debugColour)
         }
         //.background(Color.black)
         .background(

--- a/dialog/UI/IconOverlayView.swift
+++ b/dialog/UI/IconOverlayView.swift
@@ -9,8 +9,8 @@ import Foundation
 import SwiftUI
 
 struct IconOverlayView: View {
-    let overlayWidth: CGFloat = appvars.imageWidth * appvars.overlayIconScale
-    let overlayHeight: CGFloat = appvars.imageHeight * appvars.overlayIconScale
+    //var overlayWidth: CGFloat = .infinity//= appvars.imageWidth * appvars.overlayIconScale
+    //var overlayHeight: CGFloat = .infinity //= appvars.imageHeight * appvars.overlayIconScale
     
     let overlayImagePath: String = CLOptionText(OptionName: CLOptions.overlayIconOption)
     var imgFromURL: Bool = false
@@ -33,9 +33,11 @@ struct IconOverlayView: View {
     
     var sfGradientPresent: Bool = false
         
-    init(overlayWidth: CGFloat? = nil, overlayHeight: CGFloat? = nil) {
-        //self.overlayWidth = appvars.imageWidth * appvars.overlayIconScale
-        //self.overlayHeight = appvars.imageHeight * appvars.overlayIconScale
+    //init(overlayIconWidth: CGFloat? = nil, overlayIconHeight: CGFloat? = nil) {
+    init() {
+        //self.overlayWidth = overlayIconWidth ?? appvars.imageWidth * appvars.overlayIconScale
+        //self.overlayHeight = overlayIconHeight ?? appvars.imageHeight * appvars.overlayIconScale
+        
         if overlayImagePath.starts(with: "http") {
             imgFromURL = true
         }
@@ -114,9 +116,10 @@ struct IconOverlayView: View {
                         Image(systemName: "square.fill")
                             .resizable()
                             .foregroundColor(.background)
-                            .frame(width: overlayWidth, height: overlayWidth)
+                            //.frame(width: overlayWidth, height: overlayWidth)
                             .font(Font.title.weight(Font.Weight.thin))
                             .opacity(0.90)
+                            .shadow(color: .primary, radius: 1, x: 1, y: 1)
 
                         ZStack() {
                             if sfGradientPresent {
@@ -153,11 +156,14 @@ struct IconOverlayView: View {
                                 }
                             }
                         }
-                        .frame(width: overlayWidth*0.8, height: overlayWidth*0.8)
+                        .scaleEffect(0.8)
+                        //.frame(width: overlayWidth*0.8, height: overlayWidth*0.8)
                         //.shadow(color: stringToColour("#FFEEFF"), radius: 6, x: 1, y: 1)
                     }
+                    .aspectRatio(1, contentMode: .fit)
                 } else if imgFromAPP {
-                    Image(nsImage: getAppIcon(appPath: overlayImagePath, withSize: overlayWidth))
+                    //Image(nsImage: getAppIcon(appPath: overlayImagePath, withSize: overlayWidth))
+                    Image(nsImage: getAppIcon(appPath: overlayImagePath))
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .scaledToFit()
@@ -171,8 +177,8 @@ struct IconOverlayView: View {
                 }
                 
             }
-            .frame(width: overlayWidth, height: overlayHeight)
-            .offset(x: appvars.overlayOffsetX, y: appvars.overlayOffsetY)
+            //.frame(width: overlayWidth, height: overlayHeight)
+            //.offset(x: appvars.overlayOffsetX, y: appvars.overlayOffsetY)
             .shadow(color: Color.primary.opacity(0.70), radius: appvars.overlayShadow)
             //.border(Color.red)
         }

--- a/dialog/UI/IconView.swift
+++ b/dialog/UI/IconView.swift
@@ -165,7 +165,7 @@ struct IconView: View {
                                 .resizable()
                                 .foregroundColor(builtInIconColour)
                                 .font(Font.title.weight(builtInIconWeight))
-                                .frame(maxWidth: appvars.imageWidth, maxHeight: appvars.imageHeight)
+                                //.frame(maxWidth: appvars.imageWidth, maxHeight: appvars.imageHeight)
                             )
                         
                     } else {

--- a/dialog/UI/IconView.swift
+++ b/dialog/UI/IconView.swift
@@ -17,7 +17,7 @@ struct IconView: View {
     var logoHeight: CGFloat  = appvars.imageHeight
     var imgFromURL: Bool = false
     var imgFromAPP: Bool = false
-    var imgXOffset: CGFloat = 25
+    var imgXOffset: CGFloat = 0//25
     
     var builtInIconName: String = ""
     var builtInIconColour: Color = Color.primary
@@ -55,8 +55,8 @@ struct IconView: View {
             builtInIconColour = Color.white
             imgXOffset = 0
             
-            logoWidth = logoWidth * 5
-            logoHeight = logoHeight * 5
+            //logoWidth = logoWidth * 5
+            //logoHeight = logoHeight * 5
         }
         
         if messageUserImagePath.starts(with: "http") {
@@ -143,65 +143,81 @@ struct IconView: View {
     }
     
     var body: some View {
-        VStack {
-            if builtInIconPresent {
-                ZStack {
-                    if sfGradientPresent {
-                        // we need to add this twice - once as a clear version to force the right aspect ratio
-                        // and again with the gradien colour we want
-                        // the reason for this is gradient by itself is greedy and will consume the entire height and witch of the display area
-                        // this causes some SF Symbols like applelogo and applescript to look distorted
-                        Image(systemName: builtInIconName)
-                            .renderingMode(iconRenderingMode)
-                            .resizable()
-                            .foregroundColor(.clear)
-                            .font(Font.title.weight(builtInIconWeight))
-                            
-                        LinearGradient(gradient: Gradient(colors: [builtInIconColour, builtInIconSecondaryColour]), startPoint: .top, endPoint: .bottomTrailing)
-                        //LinearGradient(gradient: Gradient(colors: [.clear, .clear]), startPoint: .top, endPoint: .bottom)
-                            .mask(
+        ZStack {
+            //GeometryReader { icon in
+            //HStack {
+                if builtInIconPresent {
+                    ZStack {
+                        if sfGradientPresent {
+                            // we need to add this twice - once as a clear version to force the right aspect ratio
+                            // and again with the gradien colour we want
+                            // the reason for this is gradient by itself is greedy and will consume the entire height and witch of the display area
+                            // this causes some SF Symbols like applelogo and applescript to look distorted
                             Image(systemName: builtInIconName)
                                 .renderingMode(iconRenderingMode)
                                 .resizable()
-                                .foregroundColor(builtInIconColour)
+                                .foregroundColor(.clear)
                                 .font(Font.title.weight(builtInIconWeight))
-                                //.frame(maxWidth: appvars.imageWidth, maxHeight: appvars.imageHeight)
-                            )
-                        
-                    } else {
-                        Image(systemName: builtInIconFill)
-                            .resizable()
-                            .foregroundColor(Color.white)
-                        Image(systemName: builtInIconName)
-                            .resizable()
-                            .renderingMode(iconRenderingMode)
-                            .font(Font.title.weight(builtInIconWeight))
-                            .foregroundColor(builtInIconColour)
+                                
+                            LinearGradient(gradient: Gradient(colors: [builtInIconColour, builtInIconSecondaryColour]), startPoint: .top, endPoint: .bottomTrailing)
+                            //LinearGradient(gradient: Gradient(colors: [.clear, .clear]), startPoint: .top, endPoint: .bottom)
+                                .mask(
+                                Image(systemName: builtInIconName)
+                                    .renderingMode(iconRenderingMode)
+                                    .resizable()
+                                    .foregroundColor(builtInIconColour)
+                                    .font(Font.title.weight(builtInIconWeight))
+                                    //.frame(maxWidth: appvars.imageWidth, maxHeight: appvars.imageHeight)
+                                )
+                            
+                        } else {
+                            Image(systemName: builtInIconFill)
+                                .resizable()
+                                .foregroundColor(Color.white)
+                            Image(systemName: builtInIconName)
+                                .resizable()
+                                .renderingMode(iconRenderingMode)
+                                .font(Font.title.weight(builtInIconWeight))
+                                .foregroundColor(builtInIconColour)
+                        }
                     }
-                }
-                .aspectRatio(contentMode: .fit)
-                .scaledToFit()
-                .offset(x: imgXOffset)
-                .overlay(IconOverlayView(), alignment: .bottomTrailing)
-            } else if imgFromAPP {
-                Image(nsImage: getAppIcon(appPath: messageUserImagePath, withSize: self.logoWidth))
+                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
+                    .offset(x: imgXOffset)
+                    .scaleEffect(0.8)
+                    //.overlay(IconOverlayView(), alignment: .bottomTrailing)
+                    //.border(Color.green)
+                } else if imgFromAPP {
+                    Image(nsImage: getAppIcon(appPath: messageUserImagePath))
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .scaledToFit()
+                            .scaleEffect(0.8)
+                            //.offset(x: imgXOffset)
+                            //.overlay(IconOverlayView(), alignment: .bottomTrailing)
+                            //.border(Color.green)
+                } else {
+                    let diskImage: NSImage = getImageFromPath(fileImagePath: messageUserImagePath)
+                    Image(nsImage: diskImage)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .scaledToFit()
-                        .offset(x: imgXOffset)
-                        .overlay(IconOverlayView(), alignment: .bottomTrailing)
-            } else {
-                let diskImage: NSImage = getImageFromPath(fileImagePath: messageUserImagePath, imgWidth: logoWidth, imgHeight: logoHeight)
-                Image(nsImage: diskImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .scaledToFit()
-                    .frame(width: self.logoWidth, height: diskImage.size.height*(logoWidth/diskImage.size.width))
-                    .clipShape(RoundedRectangle(cornerRadius: 10))
-                    .offset(x: imgXOffset, y: 8)
-                    .overlay(IconOverlayView(overlayWidth: logoWidth/2, overlayHeight: diskImage.size.height*(logoWidth/diskImage.size.width)/2), alignment: .bottomTrailing)
+                        //.frame(width: self.logoWidth, height: diskImage.size.height*(logoWidth/diskImage.size.width))
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        //.offset(x: imgXOffset, y: 8)
+                        .scaleEffect(0.8)
+                        //.overlay(IconOverlayView(overlayIconWidth: logoWidth/2, overlayIconHeight: diskImage.size.height*(logoWidth/diskImage.size.width)/2), alignment: .bottomTrailing)
+                        //.border(Color.green)
 
-            }
+                }
+            //}
+            //}
+            IconOverlayView()
+                .scaleEffect(0.4, anchor:.bottomTrailing)
+                //.offset(x: 10, y: 10)
+                //.frame(width: logoWidth/2, height: logoHeight/2)
+                //.frame(alignment: .bottomTrailing)
+                //.border(Color.green)
         }
         //.overlay(IconOverlayView(), alignment: .topTrailing)
         //.border(Color.green) //debuging

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -216,7 +216,7 @@ struct AppVariables {
     
     // button default strings
     // work out how to define a default width button that does what you tell it to. in the meantime, diry hack with spaces
-    var button1Default                  = String("    OK    ")
+    var button1Default                  = String("OK")
     var button2Default                  = String("Cancel")
     var buttonInfoDefault               = String("More Information")
     var buttonInfoActionDefault         = String("")

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -150,6 +150,7 @@ struct dialogApp: App {
         appvars.imageHeight = appvars.imageHeight * appvars.scaleFactor
         
         if CLOptionPresent(OptionName: CLOptions.fullScreenWindow) {
+            appvars.overlayIconScale = appvars.overlayIconScale * 3
             FullscreenView().showFullScreen()
         }
     

--- a/dialog/dialogApp.swift
+++ b/dialog/dialogApp.swift
@@ -150,7 +150,7 @@ struct dialogApp: App {
         appvars.imageHeight = appvars.imageHeight * appvars.scaleFactor
         
         if CLOptionPresent(OptionName: CLOptions.fullScreenWindow) {
-            appvars.overlayIconScale = appvars.overlayIconScale * 3
+            //appvars.overlayIconScale = appvars.overlayIconScale * 2
             FullscreenView().showFullScreen()
         }
     

--- a/dialog/extras/Processing.swift
+++ b/dialog/extras/Processing.swift
@@ -102,14 +102,14 @@ func buttonAction(action: String, exitCode: Int32, executeShell: Bool) {
     //exit(0)
 }
 
-func getAppIcon(appPath : String, withSize : CGFloat) -> NSImage {
+func getAppIcon(appPath: String, withSize: CGFloat? = 300) -> NSImage {
     // take application path and extracts the application icon and returns is as NSImage
     // Swift implimentation of the ObjC code used in SAP's nice "Icons" utility for extracting application icons
     // https://github.com/SAP/macOS-icon-generator/blob/master/source/Icons/MTDragDropView.m#L66
     
     let image = NSImage()
     if let rep = NSWorkspace.shared.icon(forFile: appPath)
-        .bestRepresentation(for: NSRect(x: 0, y: 0, width: withSize, height: withSize), context: nil, hints: nil) {
+        .bestRepresentation(for: NSRect(x: 0, y: 0, width: withSize!, height: withSize!), context: nil, hints: nil) {
         image.size = rep.size
         image.addRepresentation(rep)
     }


### PR DESCRIPTION
Adjusted button text rendering - fixes display issue with default "OK" button in macos 12

Fixed the way icon and icon overlay are rendered. This makes scaling between different views a _lot_ more consistent.

Fixed fullscreen view rendering. Fullscreen now accepts font colours for the title. Also renders overlay icons properly in the proper scale for the display