### PR TITLE
Icon tweaking

### DIFF
--- a/dialog.xcodeproj/project.pbxproj
+++ b/dialog.xcodeproj/project.pbxproj
@@ -732,14 +732,16 @@
 		41FB6484268070CF00A54C3E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = N8GJ2Y5Z9T;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = PWA5E9TQ59;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/dialog/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogcli;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -747,14 +749,16 @@
 		41FB6485268070CF00A54C3E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = N8GJ2Y5Z9T;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = PWA5E9TQ59;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/dialog/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MARKETING_VERSION = 1.4.2;
 				PRODUCT_BUNDLE_IDENTIFIER = au.bartreardon.dialogcli;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/dialog/UI/DialogView.swift
+++ b/dialog/UI/DialogView.swift
@@ -11,6 +11,10 @@ import SwiftUI
 import AppKit
 
 struct DialogView: View {
+    
+    var imageOffsetX: CGFloat = -35
+    var imageOffsetY: CGFloat = 10
+    
     init() {
         if appvars.iconIsHidden {
             appvars.imageWidth = 0
@@ -27,7 +31,7 @@ struct DialogView: View {
                             IconView()
                             
                     }.frame(width: iconFrameWidth, height: iconFrameHeight, alignment: .top)
-                    .offset(x: -45, y: 10) //position the icon area
+                    .offset(x: imageOffsetX, y: imageOffsetY) //position the icon area
                 }
                 
                 VStack(alignment: .center) {

--- a/dialog/UI/IconOverlayView.swift
+++ b/dialog/UI/IconOverlayView.swift
@@ -30,6 +30,7 @@ struct IconOverlayView: View {
     var sfSymbolPresent: Bool = false
     
     var sfGradientPresent: Bool = false
+    var sfBackgroundIconColour: Color = Color.background
         
     init() {
         
@@ -58,6 +59,9 @@ struct IconOverlayView: View {
                 }
                 if itemName == "weight" {
                     builtInIconWeight = textToFontWeight(item[1])
+                }
+                if itemName.hasPrefix("bgcolour") || itemName.hasPrefix("bgcolor") {
+                    sfBackgroundIconColour = stringToColour(itemValue)
                 }
                 if itemName.hasPrefix("colour") || itemName.hasPrefix("color") {
                     if itemValue == "auto" {
@@ -110,7 +114,7 @@ struct IconOverlayView: View {
                             //background square so the SF Symbol has something to render against
                             Image(systemName: "square.fill")
                                 .resizable()
-                                .foregroundColor(.background)
+                                .foregroundColor(sfBackgroundIconColour)
                                 .font(Font.title.weight(Font.Weight.thin))
                                 .opacity(0.90)
                                 .shadow(color: .secondaryBackground.opacity(0.50), radius: 4, x:2, y:2) // gives the sf background some pop especially in dark mode

--- a/dialog/UI/IconOverlayView.swift
+++ b/dialog/UI/IconOverlayView.swift
@@ -106,7 +106,7 @@ struct IconOverlayView: View {
             ZStack {
                 if builtInIconPresent {
                     ZStack {
-                        if sfSymbolPresent {
+                        if sfSymbolPresent || overlayImagePath == "info" {
                             //background square so the SF Symbol has something to render against
                             Image(systemName: "square.fill")
                                 .resizable()

--- a/dialog/UI/IconOverlayView.swift
+++ b/dialog/UI/IconOverlayView.swift
@@ -86,6 +86,7 @@ struct IconOverlayView: View {
             builtInIconName = "exclamationmark.octagon.fill"
             builtInIconFill = "octagon.fill"
             builtInIconColour = Color.red
+            iconRenderingMode = Image.TemplateRenderingMode.template //force monochrome
             builtInIconPresent = true
         }
         if overlayImagePath == "caution" {

--- a/dialog/UI/IconView.swift
+++ b/dialog/UI/IconView.swift
@@ -36,6 +36,7 @@ struct IconView: View {
     var sfGradientPresent: Bool = false
     
     var mainImageScale: CGFloat = 1
+    let mainImageWithOverlayScale: CGFloat = 0.88
     let overlayImageScale: CGFloat = 0.4
     
   
@@ -44,7 +45,7 @@ struct IconView: View {
         logoHeight = appvars.imageHeight
         
         if CLOptionPresent(OptionName: CLOptions.overlayIconOption) {
-            mainImageScale = 0.8
+            mainImageScale = mainImageWithOverlayScale
         }
         
         // fullscreen runs on a dark background so invert the default icon colour for info and default

--- a/dialog/UI/IconView.swift
+++ b/dialog/UI/IconView.swift
@@ -140,7 +140,7 @@ struct IconView: View {
                 ZStack {
                     if sfGradientPresent {
                         // we need to add this twice - once as a clear version to force the right aspect ratio
-                        // and again with the gradien colour we want
+                        // and again with the gradiet colour we want
                         // the reason for this is gradient by itself is greedy and will consume the entire height and witch of the display area
                         // this causes some SF Symbols like applelogo and applescript to look distorted
                         Image(systemName: builtInIconName)

--- a/dialog/UI/IconView.swift
+++ b/dialog/UI/IconView.swift
@@ -35,11 +35,17 @@ struct IconView: View {
     
     var sfGradientPresent: Bool = false
     
+    var mainImageScale: CGFloat = 1
+    let overlayImageScale: CGFloat = 0.4
+    
   
     init() {        
         logoWidth = appvars.imageWidth
         logoHeight = appvars.imageHeight
         
+        if CLOptionPresent(OptionName: CLOptions.overlayIconOption) {
+            mainImageScale = 0.8
+        }
         
         // fullscreen runs on a dark background so invert the default icon colour for info and default
         // also set the icon offset to 0
@@ -164,13 +170,13 @@ struct IconView: View {
                 }
                 .aspectRatio(contentMode: .fit)
                 .scaledToFit()
-                .scaleEffect(0.8)
+                .scaleEffect(mainImageScale)
             } else if imgFromAPP {
                 Image(nsImage: getAppIcon(appPath: messageUserImagePath))
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .scaledToFit()
-                        .scaleEffect(0.8)
+                        .scaleEffect(mainImageScale)
             } else {
                 let diskImage: NSImage = getImageFromPath(fileImagePath: messageUserImagePath)
                 Image(nsImage: diskImage)
@@ -178,11 +184,11 @@ struct IconView: View {
                     .aspectRatio(contentMode: .fit)
                     .scaledToFit()
                     .clipShape(RoundedRectangle(cornerRadius: 10))
-                    .scaleEffect(0.8)
+                    .scaleEffect(mainImageScale)
             }
 
             IconOverlayView()
-                .scaleEffect(0.4, anchor:.bottomTrailing)
+                .scaleEffect(overlayImageScale, anchor:.bottomTrailing)
 
         }
         

--- a/dialog/appVaribles.swift
+++ b/dialog/appVaribles.swift
@@ -57,23 +57,23 @@ var helpText = """
     
                     SF Symbols - visit https://developer.apple.com/sf-symbols/ for details on over 3,100 symbols
 
-                    color,colour=<text><hex>  - specified in hex format, e.g. #00A4C7
-                                                Also accepts any of the standard Apple colours
-                                                black, blue, gray, green, orange, pink, purple, red, white, yellow
-                                                default if option is invalid is system primary colour
+                    color,colour=<text><hex>          - specified in hex format, e.g. #00A4C7
+                    bgcolor,bgcolour=<text><hex>
+                                                      Also accepts any of the standard Apple colours
+                                                      black, blue, gray, green, orange, pink, purple, red, white, yellow
+                                                      default if option is invalid is system primary colour
     
-                                              - Special colour "auto".
-                                                When used with a multicolor SF Symbol, the symbols default colour scheem will be used
-                                                ** If used with a monochrome SF Symbol **
-                                                ** it will default to black and will not respect dark mode **
+                                                      bgcolour, bgcolor will set the background colour of the icon overlay
+                                                        when SF Symbols are used
+    
+                                                      - Special colour "auto".
+                                                      When used with a multicolor SF Symbol, the symbols
+                                                        default colour scheem will be used
+                                                      ** If used with a monochrome SF Symbol **
+                                                      ** it will default to black and will not respect dark mode **
 
-                    weight=<text>             - accepts any of the following values:
-                                                    thin (default)
-                                                    light
-                                                    regular
-                                                    medium
-                                                    heavy
-                                                    bold
+                    weight=<text>                     - accepts any of the following values:
+                                                       thin (default), light, regular, medium, heavy, bold
         
         -\(CLOptions.fullScreenWindow.short), --\(CLOptions.fullScreenWindow.long)
                     Uses full screen view.


### PR DESCRIPTION
1.4.2 RC2

Tweaked how the icon and overlay icon behave.

If there's no overlay, icon is displayed larger (full scale). If there is an overlay, the icon is scaled down slightly with overlay applied to fill the space that would be otherwise occupied by a single image.

overlay icon can also have a background colour specified when using SF Symbols by adding `bgcolour=` to the image definition.